### PR TITLE
Change the module refcount mechanism.

### DIFF
--- a/module/pteditor.c
+++ b/module/pteditor.c
@@ -135,9 +135,6 @@ static int device_open(struct inode *inode, struct file *file) {
     return -EBUSY;
   }
 
-  /* Lock module */
-  try_module_get(THIS_MODULE);
-
   device_busy = true;
 
   return 0;
@@ -146,8 +143,6 @@ static int device_open(struct inode *inode, struct file *file) {
 static int device_release(struct inode *inode, struct file *file) {
   /* Unlock module */
   device_busy = false;
-
-  module_put(THIS_MODULE);
 
   return 0;
 }
@@ -566,7 +561,8 @@ static long device_ioctl(struct file *file, unsigned int ioctl_num, unsigned lon
   return 0;
 }
 
-static struct file_operations f_ops = {.unlocked_ioctl = device_ioctl,
+static struct file_operations f_ops = {.owner = THIS_MODULE,
+                                       .unlocked_ioctl = device_ioctl,
                                        .open = device_open,
                                        .release = device_release};
 


### PR DESCRIPTION
We should not use try_module_get(THIS_MODULE); to increase the refcount of the module as this happens while we are already executing code from the kernel module. This leaves a small window where the module can be removed even though it is unsafe to do so. This patch removes this part and instead sets the owner in the file_operations struct. Using this approach, the VFS increases the refcount before calling into the module, eliminating the unsafe window.