### PR TITLE
modified gitignore to exlucde build-related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,16 @@
-# ---> C
+# Prerequisites
+*.d
+
 # Object files
 *.o
 *.ko
 *.obj
 *.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
 
 # Precompiled Headers
 *.gch
@@ -31,4 +38,23 @@
 
 # Debug files
 *.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# Compilation db
+compile_commands.json
+
+# Extra Executables
+/test/tests
+/example
 


### PR DESCRIPTION
The existing gitignore file does not cover intermediate files for building the kernel module, as well as unit test and example binaries.

+ Exclude kmod-related intermediate files
+ Exclude unit test and example binaries