### PR TITLE
added ptedit_set_bit,ptedit_clear_bit

### DIFF
--- a/demos/clear_bits.c
+++ b/demos/clear_bits.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+
+#include "../ptedit_header.h"
+
+
+int main(int argc, char** argv)
+{
+  if (ptedit_init()) {
+      printf("Error: Could not initalize PTEditor, did you load the kernel module?\n");
+      return 1;
+  }
+  
+  unsigned char* addr = (unsigned char*) mmap(NULL,2*1024*1024, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  memset(addr,0x42,2*1024*1024);
+  
+  ptedit_entry_t entry = ptedit_resolve(addr, 0);
+  ptedit_clear_bit(addr, 0, PTEDIT_PAGE_BIT_ACCESSED,PTEDIT_VALID_MASK_PUD|PTEDIT_VALID_MASK_PMD|PTEDIT_VALID_MASK_PTE);
+  entry = ptedit_resolve(addr, 0);
+  ptedit_print_entry(entry.pte);
+  ptedit_print_entry(entry.pmd);
+  ptedit_print_entry(entry.pud);
+  ptedit_set_bit(addr, 0, PTEDIT_PAGE_BIT_ACCESSED,PTEDIT_VALID_MASK_PUD|PTEDIT_VALID_MASK_PMD|PTEDIT_VALID_MASK_PTE);
+  entry = ptedit_resolve(addr, 0);
+  ptedit_print_entry(entry.pte);
+  ptedit_print_entry(entry.pmd);
+  ptedit_print_entry(entry.pud);
+
+  //clear accessed bit of pd entry
+  size_t address_pfn = ptedit_get_pfn(entry.pd);
+  ptedit_set_bit(addr, 0, PTEDIT_PAGE_BIT_ACCESSED,PTEDIT_VALID_MASK_PMD);
+  munmap(addr,4096);
+
+  ptedit_cleanup();
+
+  return 0;
+}

--- a/ptedit.c
+++ b/ptedit.c
@@ -890,6 +890,62 @@ ptedit_fnc void ptedit_pte_clear_bit(void* address, pid_t pid, int bit) {
     ptedit_update(address, pid, &vm);
 }
 
+ptedit_fnc void ptedit_set_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels) {
+    ptedit_entry_t vm = ptedit_resolve(address, pid);
+    size_t bitmask = (1ull << bit);
+    
+    if ((vm.valid & PTEDIT_VALID_MASK_PTE) && (paging_affected_levels & PTEDIT_VALID_MASK_PTE)) {
+        vm.pte |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PTE;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PMD) && (paging_affected_levels & PTEDIT_VALID_MASK_PMD) && ptedit_paging_definition.has_pmd) {
+        vm.pmd |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PMD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PUD) && (paging_affected_levels & PTEDIT_VALID_MASK_PUD) && ptedit_paging_definition.has_pud) {
+        vm.pud |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PUD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_P4D) && (paging_affected_levels & PTEDIT_VALID_MASK_P4D) && ptedit_paging_definition.has_p4d) {
+        vm.p4d |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_P4D;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PGD) && (paging_affected_levels & PTEDIT_VALID_MASK_PGD) && ptedit_paging_definition.has_pgd) {
+        vm.pgd |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PGD;
+    }
+
+    ptedit_update(address, pid, &vm);
+}
+
+ptedit_fnc void ptedit_clear_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels) {
+    ptedit_entry_t vm = ptedit_resolve(address, pid);
+    size_t bitmask = ~(1ull << bit);
+    
+    if ((vm.valid & PTEDIT_VALID_MASK_PTE) && (paging_affected_levels & PTEDIT_VALID_MASK_PTE)) {
+        vm.pte &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PTE;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PMD) && (paging_affected_levels & PTEDIT_VALID_MASK_PMD) && ptedit_paging_definition.has_pmd) {
+        vm.pmd &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PMD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PUD) && (paging_affected_levels & PTEDIT_VALID_MASK_PUD) && ptedit_paging_definition.has_pud) {
+        vm.pud &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PUD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_P4D) && (paging_affected_levels & PTEDIT_VALID_MASK_P4D) && ptedit_paging_definition.has_p4d) {
+        vm.p4d &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_P4D;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PGD) && (paging_affected_levels & PTEDIT_VALID_MASK_PGD) && ptedit_paging_definition.has_pgd) {
+        vm.pgd &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PGD;
+    }
+
+    ptedit_update(address, pid, &vm);
+}
+
 // ---------------------------------------------------------------------------
 ptedit_fnc unsigned char ptedit_pte_get_bit(void* address, pid_t pid, int bit) {
     ptedit_entry_t vm = ptedit_resolve(address, pid);

--- a/ptedit.h
+++ b/ptedit.h
@@ -257,6 +257,27 @@ ptedit_fnc void ptedit_pte_set_bit(void* address, pid_t pid, int bit);
 ptedit_fnc void ptedit_pte_clear_bit(void* address, pid_t pid, int bit);
 
 /**
+ * Clears one or multiple bits directly in the different paging levels of an address.
+ *
+ * @param[in] address The virtual address
+ * @param[in] pid The pid of the process (0 for own process)
+ * @param[in] bit The bit to clear (one of PTEDIT_PAGE_BIT_*)
+ * @param[in] paging_affected_levels Bitfield of affected page levels
+ */
+ptedit_fnc void ptedit_set_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels);
+
+
+/**
+ * Clears one or multiple bits directly in the different paging levels of an address.
+ *
+ * @param[in] address The virtual address
+ * @param[in] pid The pid of the process (0 for own process)
+ * @param[in] bit The bit to clear (one of PTEDIT_PAGE_BIT_*)
+ * @param[in] paging_affected_levels Bitfield of affected page levels
+ */
+ptedit_fnc void ptedit_clear_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels);
+
+/**
  * Returns the value of a bit directly from the PTE of an address.
  *
  * @param[in] address The virtual address
@@ -378,6 +399,7 @@ typedef struct {
     size_t execution_disabled : 1;
 } ptedit_pte_t;
 #pragma pack(pop)
+
 
 #elif defined(__aarch64__)
 #define PTEDIT_PAGE_PRESENT 3

--- a/ptedit_header.h
+++ b/ptedit_header.h
@@ -414,6 +414,27 @@ ptedit_fnc void ptedit_pte_set_bit(void* address, pid_t pid, int bit);
 ptedit_fnc void ptedit_pte_clear_bit(void* address, pid_t pid, int bit);
 
 /**
+ * Clears one or multiple bits directly in the different paging levels of an address.
+ *
+ * @param[in] address The virtual address
+ * @param[in] pid The pid of the process (0 for own process)
+ * @param[in] bit The bit to clear (one of PTEDIT_PAGE_BIT_*)
+ * @param[in] paging_affected_levels Bitfield of affected page levels
+ */
+ptedit_fnc void ptedit_set_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels);
+
+
+/**
+ * Clears one or multiple bits directly in the different paging levels of an address.
+ *
+ * @param[in] address The virtual address
+ * @param[in] pid The pid of the process (0 for own process)
+ * @param[in] bit The bit to clear (one of PTEDIT_PAGE_BIT_*)
+ * @param[in] paging_affected_levels Bitfield of affected page levels
+ */
+ptedit_fnc void ptedit_clear_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels);
+
+/**
  * Returns the value of a bit directly from the PTE of an address.
  *
  * @param[in] address The virtual address
@@ -535,6 +556,7 @@ typedef struct {
     size_t execution_disabled : 1;
 } ptedit_pte_t;
 #pragma pack(pop)
+
 
 #elif defined(__aarch64__)
 #define PTEDIT_PAGE_PRESENT 3
@@ -1858,6 +1880,62 @@ ptedit_fnc void ptedit_pte_clear_bit(void* address, pid_t pid, int bit) {
     if (!(vm.valid & PTEDIT_VALID_MASK_PTE)) return;
     vm.pte &= ~(1ull << bit);
     vm.valid = PTEDIT_VALID_MASK_PTE;
+    ptedit_update(address, pid, &vm);
+}
+
+ptedit_fnc void ptedit_set_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels) {
+    ptedit_entry_t vm = ptedit_resolve(address, pid);
+    size_t bitmask = (1ull << bit);
+    
+    if ((vm.valid & PTEDIT_VALID_MASK_PTE) && (paging_affected_levels & PTEDIT_VALID_MASK_PTE)) {
+        vm.pte |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PTE;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PMD) && (paging_affected_levels & PTEDIT_VALID_MASK_PMD) && ptedit_paging_definition.has_pmd) {
+        vm.pmd |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PMD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PUD) && (paging_affected_levels & PTEDIT_VALID_MASK_PUD) && ptedit_paging_definition.has_pud) {
+        vm.pud |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PUD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_P4D) && (paging_affected_levels & PTEDIT_VALID_MASK_P4D) && ptedit_paging_definition.has_p4d) {
+        vm.p4d |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_P4D;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PGD) && (paging_affected_levels & PTEDIT_VALID_MASK_PGD) && ptedit_paging_definition.has_pgd) {
+        vm.pgd |= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PGD;
+    }
+
+    ptedit_update(address, pid, &vm);
+}
+
+ptedit_fnc void ptedit_clear_bit(void* address, pid_t pid, int bit,size_t paging_affected_levels) {
+    ptedit_entry_t vm = ptedit_resolve(address, pid);
+    size_t bitmask = ~(1ull << bit);
+    
+    if ((vm.valid & PTEDIT_VALID_MASK_PTE) && (paging_affected_levels & PTEDIT_VALID_MASK_PTE)) {
+        vm.pte &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PTE;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PMD) && (paging_affected_levels & PTEDIT_VALID_MASK_PMD) && ptedit_paging_definition.has_pmd) {
+        vm.pmd &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PMD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PUD) && (paging_affected_levels & PTEDIT_VALID_MASK_PUD) && ptedit_paging_definition.has_pud) {
+        vm.pud &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PUD;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_P4D) && (paging_affected_levels & PTEDIT_VALID_MASK_P4D) && ptedit_paging_definition.has_p4d) {
+        vm.p4d &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_P4D;
+    }
+    if ((vm.valid & PTEDIT_VALID_MASK_PGD) && (paging_affected_levels & PTEDIT_VALID_MASK_PGD) && ptedit_paging_definition.has_pgd) {
+        vm.pgd &= bitmask;
+        vm.valid |= PTEDIT_VALID_MASK_PGD;
+    }
+
     ptedit_update(address, pid, &vm);
 }
 

--- a/test/tests.c
+++ b/test/tests.c
@@ -247,6 +247,31 @@ UTEST(pte, pte_set_pfn) {
     ASSERT_TRUE(accessor[0] == 2);
 }
 
+// =========================================================================
+//                             Bit Modifications in Paging
+// =========================================================================
+UTEST(pte, ptedit_clear_bit) {
+    memset(page1,0x42,4096);
+    ptedit_clear_bit(page1, 0, PTEDIT_PAGE_BIT_ACCESSED,PTEDIT_VALID_MASK_PUD|PTEDIT_VALID_MASK_PMD|PTEDIT_VALID_MASK_PTE);
+    ptedit_entry_t entry = ptedit_resolve(page1, 0);
+    ASSERT_TRUE(PTEDIT_B(entry.pte, PTEDIT_PAGE_BIT_ACCESSED) == 0);
+    ASSERT_TRUE(PTEDIT_B(entry.pud, PTEDIT_PAGE_BIT_ACCESSED) == 0);
+    ASSERT_TRUE(PTEDIT_B(entry.pd, PTEDIT_PAGE_BIT_ACCESSED) == 0);
+}
+
+UTEST(pte, ptedit_set_bit) {
+    memset(page1,0x42,4096);
+    ptedit_clear_bit(page1, 0, PTEDIT_PAGE_BIT_ACCESSED,PTEDIT_VALID_MASK_PUD|PTEDIT_VALID_MASK_PMD|PTEDIT_VALID_MASK_PTE);
+    ptedit_entry_t entry = ptedit_resolve(page1, 0);
+    ASSERT_TRUE(PTEDIT_B(entry.pte, PTEDIT_PAGE_BIT_ACCESSED) == 0);
+    ASSERT_TRUE(PTEDIT_B(entry.pud, PTEDIT_PAGE_BIT_ACCESSED) == 0);
+    ASSERT_TRUE(PTEDIT_B(entry.pd, PTEDIT_PAGE_BIT_ACCESSED) == 0);
+    ptedit_set_bit(page1, 0, PTEDIT_PAGE_BIT_ACCESSED,PTEDIT_VALID_MASK_PUD|PTEDIT_VALID_MASK_PMD|PTEDIT_VALID_MASK_PTE);
+    entry = ptedit_resolve(page1, 0);
+    ASSERT_TRUE(PTEDIT_B(entry.pte, PTEDIT_PAGE_BIT_ACCESSED) == 1);
+    ASSERT_TRUE(PTEDIT_B(entry.pud, PTEDIT_PAGE_BIT_ACCESSED) == 1);
+    ASSERT_TRUE(PTEDIT_B(entry.pd, PTEDIT_PAGE_BIT_ACCESSED) == 1);
+}
 
 // =========================================================================
 //                             Physical Pages


### PR DESCRIPTION
Bits can now be set and cleared in all different paging levels.

An example call would look like this to clear the accessed bit in both the PTE and PMD:
ptedit_clear_bit(addr, 0, PTEDIT_PAGE_BIT_ACCESSED,PTEDIT_VALID_MASK_PMD|,PTEDIT_VALID_MASK_PTE);