### PR TITLE
Make ptedit_paging_definition_t static

### DIFF
--- a/ptedit_header.h
+++ b/ptedit_header.h
@@ -1037,7 +1037,7 @@ typedef struct {
     int page_offset;
 } ptedit_paging_definition_t;
 
-ptedit_paging_definition_t ptedit_paging_definition;
+static ptedit_paging_definition_t ptedit_paging_definition;
 
 
 


### PR DESCRIPTION
Make ptedit_paging_definition_t static in order to be able to include ptedit_header.h into multiple .cpp files.