### PR TITLE
Declare Functions as "extern C"

### DIFF
--- a/ptedit.h
+++ b/ptedit.h
@@ -3,6 +3,10 @@
 #ifndef _PTEDITOR_H_
 #define _PTEDITOR_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ptedit_fnc
 
 #include "module/pteditor.h"
@@ -811,5 +815,9 @@ ptedit_fnc void ptedit_print_entry(size_t entry);
 ptedit_fnc void ptedit_print_entry_line(size_t entry, int line);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/ptedit_header.h
+++ b/ptedit_header.h
@@ -5,6 +5,10 @@
 #ifndef PTEDITOR_MODULE_H
 #define PTEDITOR_MODULE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(__linux__) || defined(__linux) || defined(__unix__) || defined(LINUX) || defined(UNIX)
 #define LINUX
 #endif
@@ -1887,3 +1891,7 @@ ptedit_fnc void ptedit_pte_set_pfn(void* address, pid_t pid, size_t pfn) {
     vm.valid = PTEDIT_VALID_MASK_PTE;
     ptedit_update(address, pid, &vm);
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This change allows including the header from C++ code without explicitly telling the compiler to treat the files differently.