### PR TITLE
Fix TLB invalidation for PID != 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ System Info | Descriptions
 
  TLB/Barriers       | Descriptions
 --------------------------------|---------------------------------------------
-`void `[`ptedit_invalidate_tlb`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(void * address)`            | Invalidates the TLB for a given address on all CPUs.
+`void `[`ptedit_invalidate_tlb`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(void * address)`            | Invalidates the TLB entry of current process for a given address on all CPUs.
+`void `[`ptedit_invalidate_tlb_pid`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(pid_t pid, void * address)`            | Invalidates the TLB for a given PID and address on all CPUs.
 `void `[`ptedit_full_serializing_barrier`](#group__BARRIERS_1ga35efff6b34856596b467ef3a5075adc6)`()`            | A full serializing barrier which stops everything.
 
  Memory types (PATs/MAIRs)       | Descriptions

--- a/module/pteditor.h
+++ b/module/pteditor.h
@@ -90,6 +90,14 @@ typedef struct {
     size_t root;
 } ptedit_paging_t;
 
+/**
+ * Structure to hold the arguments for TLB invalidation
+ */
+typedef struct {
+    pid_t pid;
+    void* address;
+} ptedit_invalidate_tlb_args_t;
+
 #define PTEDIT_VALID_MASK_PGD (1<<0)
 #define PTEDIT_VALID_MASK_P4D (1<<1)
 #define PTEDIT_VALID_MASK_PUD (1<<2)
@@ -140,6 +148,9 @@ typedef struct {
 
 #define PTEDITOR_IOCTL_CMD_SWITCH_TLB_INVALIDATION \
   _IOR(PTEDITOR_IOCTL_MAGIC_NUMBER, 13, size_t)
+
+#define PTEDITOR_IOCTL_CMD_INVALIDATE_TLB_PID \
+  _IOR(PTEDITOR_IOCTL_MAGIC_NUMBER, 14, size_t)
 #else
 #define PTEDITOR_READ_PAGE CTL_CODE(FILE_DEVICE_UNKNOWN, 0x801, METHOD_BUFFERED, FILE_ANY_ACCESS)
 #define PTEDITOR_WRITE_PAGE CTL_CODE(FILE_DEVICE_UNKNOWN, 0x802, METHOD_BUFFERED, FILE_READ_DATA)

--- a/ptedit.h
+++ b/ptedit.h
@@ -632,12 +632,20 @@ ptedit_fnc void ptedit_set_paging_root(pid_t pid, size_t root);
  */
 
  /**
-  * Invalidates the TLB for a given address on all CPUs.
+  * Invalidates the TLB for a given address (belonging to the current process) on all CPUs.
   *
   * @param[in] address The address to invalidate
   *
   */
 ptedit_fnc void ptedit_invalidate_tlb(void* address);
+
+ /**
+  * Invalidates the TLB for a given address (belonging to the specified pid) on all CPUs.
+  *
+  * @param[in] address The address to invalidate
+  *
+  */
+ptedit_fnc void ptedit_invalidate_tlb_pid(pid_t pid, void* address);
 
  /**
   * Change the method used for flushing the TLB (either kernel or custom function)


### PR DESCRIPTION
The TLB invalidation using the Linux kernel variant was only cleared the TLB for the calling process. This affects explicit (i.e., calls to `ptedit_invalidate_tlb`) and implicit (e.g., after `ptedit_update` in the kmodule) TLB invalidations.

This patch introduces a new function, i.e., `ptedit_invalidate_tlb_pid`, allowing to also clear the TLB when modifying entries of different PIDs. While the old API function is kept for backwards compatibility reasons, all internal calls now use the new function.

The patch was tested on Ubuntu 22.04 (Linux 5.15.0-122-generic) using both, the previous and updated userspace header files.