### PR TITLE
Fix virt2phys.c demo 2MB translation

### DIFF
--- a/demos/virt2phys.c
+++ b/demos/virt2phys.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     } else {
         printf(TAG_PROGRESS "Page is 2MB\n");
         ptedit_print_entry(entry.pd);
-        phys = (ptedit_get_pfn(entry.pd) << 21) | (((size_t)&target) & 0x1fffff);
+        phys = (ptedit_get_pfn(entry.pd) << 12) | (((size_t)&target) & 0x1fffff);
     }
 
     printf(TAG_OK "Virtual address: %p\n", &target);


### PR DESCRIPTION
Since ptedit_get_pfn parses entry.pd like a pte, it also needs to be shifted like one, otherwise the results is off by 9 bits