### PR TITLE
Bugfix: TLB Invalidation on kernel 6.6+ | Remove Custom TLB Invalidation for x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ System Info | Descriptions
 `void `[`ptedit_invalidate_tlb`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(void * address)`            | Invalidates the TLB entry of current process for a given address on all CPUs.
 `void `[`ptedit_invalidate_tlb_pid`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(pid_t pid, void * address)`            | Invalidates the TLB for a given PID and address on all CPUs.
 `void `[`ptedit_full_serializing_barrier`](#group__BARRIERS_1ga35efff6b34856596b467ef3a5075adc6)`()`            | A full serializing barrier which stops everything.
+`int `[`ptedit_switch_tlb_invalidation`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(int implementation)`            | The implementation to use, either PTEDITOR_TLB_INVALIDATION_KERNEL or PTEDITOR_TLB_INVALIDATION_CUSTOM (unsupported on x86).
 
  Memory types (PATs/MAIRs)       | Descriptions
 --------------------------------|---------------------------------------------

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ System Info | Descriptions
 `void `[`ptedit_invalidate_tlb`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(void * address)`            | Invalidates the TLB entry of current process for a given address on all CPUs.
 `void `[`ptedit_invalidate_tlb_pid`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(pid_t pid, void * address)`            | Invalidates the TLB for a given PID and address on all CPUs.
 `void `[`ptedit_full_serializing_barrier`](#group__BARRIERS_1ga35efff6b34856596b467ef3a5075adc6)`()`            | A full serializing barrier which stops everything.
-`int `[`ptedit_switch_tlb_invalidation`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(int implementation)`            | The implementation to use, either PTEDITOR_TLB_INVALIDATION_KERNEL or PTEDITOR_TLB_INVALIDATION_CUSTOM (unsupported on x86).
+`int `[`ptedit_switch_tlb_invalidation`](#group__BARRIERS_1gad2d64fa589bc626ba41ccf18c60d159f)`(int implementation)`            | The implementation to use, either `PTEDITOR_TLB_INVALIDATION_KERNEL` or `PTEDITOR_TLB_INVALIDATION_CUSTOM` (unsupported on x86).
 
  Memory types (PATs/MAIRs)       | Descriptions
 --------------------------------|---------------------------------------------

--- a/test/tests.c
+++ b/test/tests.c
@@ -450,12 +450,15 @@ UTEST(tlb, access_time_kernel_tlb_flush) {
     ASSERT_GT(flushed, normal);
 }
 
+// custom TLB invalidation is not supported on all CPUs
+#if !(defined(__i386__) || defined(__x86_64__))
 UTEST(tlb, access_time_custom_tlb_flush) {
     ptedit_switch_tlb_invalidation(PTEDITOR_TLB_INVALIDATION_CUSTOM);
     int flushed = access_time_ext(scratch, 100, ptedit_invalidate_tlb);
     int normal = access_time_ext(scratch, 100, NULL);
     ASSERT_GT(flushed, normal);
 }
+#endif
 
 int main(int argc, const char *const argv[]) {
     if(ptedit_init()) {


### PR DESCRIPTION
[Starting from kernel version 6.6](https://github.com/torvalds/linux/commit/54e3d9434ef61b97fd3263c141b928dc5635e50d), Linux changed how their TLB invalidation should be called.
As PTEditor reuses the same APIs to implement its custom TLB invalidation, this leads to a broken TLB invalidation. Naturally, resulting is nasty bugs.

This PR disables the custom TLB invalidation entirely for x86 CPUs as it is not needed anymore. The reasoning behind this is that the current and future implementation of the custom TLB invalidation for x86 would just reimplement the Linux functions. On x86, calls to `ptedit_switch_tlb_invalidation` are now no-ops, i.e., they return 0 (to stay backwards compatible) and print a warning in the kernel log.

PS: also added a README entry for `ptedit_switch_tlb_invalidation`