### PR TITLE
bugfix: add missing errorcheck in tlb invalidation

### DIFF
--- a/module/pteditor.c
+++ b/module/pteditor.c
@@ -190,7 +190,9 @@ void _flush_tlb_page_smp(void* info) {
 static void
 invalidate_tlb_kernel(pid_t pid, void* addr) {
 #if defined(__i386__) || defined(__x86_64__)
-  flush_tlb_mm_range_func(get_mm(pid), (unsigned long) addr, (unsigned long) addr + real_page_size, real_page_shift, false);
+  struct mm_struct* mm = get_mm(pid);
+  if (!mm) return; // process might have already been killed
+  flush_tlb_mm_range_func(mm, (unsigned long) addr, (unsigned long) addr + real_page_size, real_page_shift, false);
 #elif defined(__aarch64__)
   struct vm_area_struct *vma = find_vma(current->mm, (unsigned long)addr);
   tlb_page_t tlb_page;


### PR DESCRIPTION
This patch adds a missing error check to `invalidate_tlb_kernel`. I suspect that this was one if the issues on kernel versions 6.1.0+. With the patch, I still observe `rcu_preempt detected stalls` but the fatal hangs seem gone.

Note that PTEditor currently still requires IBT to be disabled, e.g., via the kernel flag `ibt=off`.

This fix is very likely related to #44